### PR TITLE
Refactor the semantics of `list.get`

### DIFF
--- a/client/src/main/java/org/dst/client/DstListProxy.java
+++ b/client/src/main/java/org/dst/client/DstListProxy.java
@@ -28,8 +28,9 @@ public class DstListProxy {
 
   public List<String> get(String key) {
     ListProtocol.GetRequest request = ListProtocol.GetRequest.newBuilder()
-          .setKey(key)
-          .build();
+        .setType(ListProtocol.GetType.GET_ALL)
+        .setKey(key)
+        .build();
     ListProtocol.GetResponse response = service.get(request);
     if (response.getStatus() == CommonProtocol.Status.KEY_NOT_FOUND) {
       throw new KeyNotFoundException(key);

--- a/common/src/main/java/org/dst/common/exception/DstListIndexOutOfBoundsException.java
+++ b/common/src/main/java/org/dst/common/exception/DstListIndexOutOfBoundsException.java
@@ -1,0 +1,16 @@
+package org.dst.common.exception;
+
+public class DstListIndexOutOfBoundsException extends DstException {
+
+  protected String key;
+
+  public DstListIndexOutOfBoundsException(String key, Exception t) {
+    super(String.format("The index is out of bounds of the list %s", key), t);
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+}

--- a/core/src/main/java/org/dst/core/operatorImpl/DstListImpl.java
+++ b/core/src/main/java/org/dst/core/operatorImpl/DstListImpl.java
@@ -1,5 +1,6 @@
 package org.dst.core.operatorImpl;
 
+import org.dst.common.exception.DstListIndexOutOfBoundsException;
 import org.dst.core.DstMapInterface;
 import org.dst.core.DstConcurrentHashMapImpl;
 import org.dst.core.operatorset.DstList;
@@ -27,6 +28,31 @@ public class DstListImpl implements DstList {
       throw new KeyNotFoundException(key);
     }
     return listMap.get(key);
+  }
+
+  @Override
+  public String get(String key, int index) throws KeyNotFoundException, IndexOutOfBoundsException {
+    try {
+      final List<String> list = listMap.get(key);
+      return list.get(index);
+    } catch (NullPointerException e) {
+      throw new KeyNotFoundException(key);
+    } catch (IndexOutOfBoundsException e) {
+      throw new DstListIndexOutOfBoundsException(key, e);
+    }
+  }
+
+  @Override
+  public List<String> get(String key, int from, int end)
+      throws KeyNotFoundException, IndexOutOfBoundsException {
+    try {
+      final List<String> list = listMap.get(key);
+      return list.subList(from, end);
+    } catch (NullPointerException e) {
+      throw new KeyNotFoundException(key);
+    } catch (IndexOutOfBoundsException e) {
+      throw new DstListIndexOutOfBoundsException(key, e);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/dst/core/operatorset/DstList.java
+++ b/core/src/main/java/org/dst/core/operatorset/DstList.java
@@ -2,8 +2,6 @@ package org.dst.core.operatorset;
 
 import org.dst.common.exception.KeyNotFoundException;
 import org.dst.common.utils.Status;
-
-import java.security.Key;
 import java.util.List;
 
 public interface DstList {
@@ -31,16 +29,19 @@ public interface DstList {
    * @param index The index that we want get the value at.
    * @return The value at the given index from the list.
    */
-  String get(String key, int index) throws KeyNotFoundException, IndexOutOfBoundsException;
+  String get(String key, int index)
+      throws KeyNotFoundException, IndexOutOfBoundsException;
 
   /**
+   * Get the values of the given range.
    *
-   * @param key
-   * @param from
-   * @param end
-   * @return
+   * @param key The key of the list.
+   * @param from The left index of the range.
+   * @param end The right index of the range.
+   * @return The values of the given range.
    */
-  List<String> get(String key, int from, int end) throws KeyNotFoundException, IndexOutOfBoundsException;
+  List<String> get(String key, int from, int end)
+      throws KeyNotFoundException, IndexOutOfBoundsException;
 
   /**
    * This method will delete a list value based on the key

--- a/core/src/main/java/org/dst/core/operatorset/DstList.java
+++ b/core/src/main/java/org/dst/core/operatorset/DstList.java
@@ -1,6 +1,9 @@
 package org.dst.core.operatorset;
 
+import org.dst.common.exception.KeyNotFoundException;
 import org.dst.common.utils.Status;
+
+import java.security.Key;
 import java.util.List;
 
 public interface DstList {
@@ -17,9 +20,27 @@ public interface DstList {
    * This method will query a list value based on the key
    *
    * @param key Obtain a list value based on the key
-   * @return the list value
+   * @return the list value.
    */
-  List<String> get(String key);
+  List<String> get(String key) throws KeyNotFoundException;
+
+  /**
+   * Get the value of the given index from the list.
+   *
+   * @param key The key of the list.
+   * @param index The index that we want get the value at.
+   * @return The value at the given index from the list.
+   */
+  String get(String key, int index) throws KeyNotFoundException, IndexOutOfBoundsException;
+
+  /**
+   *
+   * @param key
+   * @param from
+   * @param end
+   * @return
+   */
+  List<String> get(String key, int from, int end) throws KeyNotFoundException, IndexOutOfBoundsException;
 
   /**
    * This method will delete a list value based on the key

--- a/parser/src/main/java/org/dst/parser/DstNewSQL.g4
+++ b/parser/src/main/java/org/dst/parser/DstNewSQL.g4
@@ -17,15 +17,14 @@ strPut: 'str.put' key value;
 strGet: 'str.get' key ;
 
 // list concept
-listStatement: listPut | listLput | listRput | listGet | listRGet | listLdel | listRdel;
+listStatement: listPut | listLput | listRput | listGet | listRGet | listDelete | listMDelete;
 listPut: 'list.put' key valueArray;
 listLput: 'list.lput' key valueArray;
 listRput: 'list.rput' key valueArray;
 listGet: 'list.get' listGetArguments;
 listRGet: 'list.rget' listGetArguments;
-listLdel: 'list.ldel' key index;
-listRdel: 'list.rdel' key index;
-
+listDelete: 'list.del' (listDeleteOne | listDeleteRange);
+listMDelete: 'list.mdel' key (index)+;
 
 listGetArguments: listGetAll | listGetOne | listGetRange;
 // Get the all values of this list.
@@ -34,6 +33,9 @@ listGetAll: key;
 listGetOne: key index;
 // Get the specific values by the given range.
 listGetRange: key index index;
+
+listDeleteOne: key index;
+listDeleteRange: key index index;
 
 
 // set concept

--- a/parser/src/main/java/org/dst/parser/DstNewSQL.g4
+++ b/parser/src/main/java/org/dst/parser/DstNewSQL.g4
@@ -4,6 +4,10 @@ grammar DstNewSQL;
 package org.dst.parser.generated;
 }
 
+/**
+* This is the Dst new SQL grammar definition.
+*/
+
 statement: (conceptStatement) EOF;
 conceptStatement: strStatement | listStatement | setStatement | dictStatement;
 
@@ -13,13 +17,23 @@ strPut: 'str.put' key value;
 strGet: 'str.get' key ;
 
 // list concept
-listStatement: listPut | listGet | listLput | listRput | listLdel | listRdel;
+listStatement: listPut | listLput | listRput | listGet | listRGet | listLdel | listRdel;
 listPut: 'list.put' key valueArray;
-listGet: 'list.get' key;
 listLput: 'list.lput' key valueArray;
 listRput: 'list.rput' key valueArray;
+listGet: 'list.get' listGetArguments;
+listRGet: 'list.rget' listGetArguments;
 listLdel: 'list.ldel' key index;
 listRdel: 'list.rdel' key index;
+
+
+listGetArguments: listGetAll | listGetOne | listGetRange;
+// Get the all values of this list.
+listGetAll: key;
+// Get the specific value of the given index.
+listGetOne: key index;
+// Get the specific values by the given range.
+listGetRange: key index index;
 
 
 // set concept

--- a/parser/src/main/java/org/dst/parser/DstNewSQL.g4
+++ b/parser/src/main/java/org/dst/parser/DstNewSQL.g4
@@ -21,7 +21,7 @@ listStatement: listPut | listLput | listRput | listGet | listRGet | listDelete |
 listPut: 'list.put' key valueArray;
 listLput: 'list.lput' key valueArray;
 listRput: 'list.rput' key valueArray;
-listGet: 'list.get' listGetArguments;
+listGet: 'list.get' (listGetAll | listGetOne | listGetRange);
 listRGet: 'list.rget' listGetArguments;
 listDelete: 'list.del' (listDeleteOne | listDeleteRange);
 listMDelete: 'list.mdel' key (index)+;

--- a/parser/src/main/java/org/dst/parser/DstNewSqlListener.java
+++ b/parser/src/main/java/org/dst/parser/DstNewSqlListener.java
@@ -61,15 +61,6 @@ public class DstNewSqlListener extends DstNewSQLBaseListener {
   }
 
   @Override
-  public void enterListGet(DstNewSQLParser.ListGetContext ctx) {
-    Preconditions.checkState(parsedResult == null);
-    Preconditions.checkState(ctx.children.size() == 2);
-    ListProtocol.GetRequest.Builder builder = ListProtocol.GetRequest.newBuilder();
-    builder.setKey(ctx.children.get(1).getText());
-    parsedResult = new DstParsedResult(RequestTypeEnum.LIST_GET, builder.build());
-  }
-
-  @Override
   public void enterListLput(DstNewSQLParser.ListLputContext ctx) {
     Preconditions.checkState(parsedResult == null);
     Preconditions.checkState(ctx.children.size() == 3);
@@ -96,23 +87,39 @@ public class DstNewSqlListener extends DstNewSQLBaseListener {
   }
 
   @Override
-  public void enterListLdel(DstNewSQLParser.ListLdelContext ctx) {
+  public void enterListGet(DstNewSQLParser.ListGetContext ctx) {
     Preconditions.checkState(parsedResult == null);
-    Preconditions.checkState(ctx.children.size() == 3);
-    ListProtocol.LDelRequest.Builder builder = ListProtocol.LDelRequest.newBuilder();
-    builder.setKey(ctx.children.get(1).getText());
-    builder.setIndex(Integer.valueOf(ctx.children.get(2).getText()));
-    parsedResult = new DstParsedResult(RequestTypeEnum.LIST_LDEL, builder.build());
+    Preconditions.checkState(ctx.children.size() == 2);
+    final ParseTree listGetArgumentsParseTree = ctx.children.get(1);
+    final int numArguments = listGetArgumentsParseTree.getChildCount();
+
+    if (1 == numArguments) {
+      // GET_ALL
+      final String key = listGetArgumentsParseTree.getChild(0).getText();
+
+    } else if (2 == numArguments) {
+      // get one
+    } else if (3 == numArguments) {
+      // get range
+    } else {
+      // exception
+    }
+
   }
 
   @Override
-  public void enterListRdel(DstNewSQLParser.ListRdelContext ctx) {
-    Preconditions.checkState(parsedResult == null);
-    Preconditions.checkState(ctx.children.size() == 3);
-    ListProtocol.RDelRequest.Builder builder = ListProtocol.RDelRequest.newBuilder();
-    builder.setKey(ctx.children.get(1).getText());
-    builder.setIndex(Integer.valueOf(ctx.children.get(2).getText()));
-    parsedResult = new DstParsedResult(RequestTypeEnum.LIST_RDEL, builder.build());
+  public void enterListRGet(DstNewSQLParser.ListRGetContext ctx) {
+    // TODO(qwang): Refine.
+  }
+
+  @Override
+  public void enterListDelete(DstNewSQLParser.ListDeleteContext ctx) {
+    // TODO(qwang): Refine.
+  }
+
+  @Override
+  public void enterListMDelete(DstNewSQLParser.ListMDeleteContext ctx) {
+    // TODO(qwang): Refine.
   }
 
   @Override

--- a/parser/src/main/java/org/dst/parser/DstNewSqlListener.java
+++ b/parser/src/main/java/org/dst/parser/DstNewSqlListener.java
@@ -93,18 +93,29 @@ public class DstNewSqlListener extends DstNewSQLBaseListener {
     final ParseTree listGetArgumentsParseTree = ctx.children.get(1);
     final int numArguments = listGetArgumentsParseTree.getChildCount();
 
+    ListProtocol.GetRequest.Builder builder = ListProtocol.GetRequest.newBuilder();
+    final String key = listGetArgumentsParseTree.getChild(0).getText();
+    builder.setKey(key);
     if (1 == numArguments) {
       // GET_ALL
-      final String key = listGetArgumentsParseTree.getChild(0).getText();
-
+      Preconditions.checkState(listGetArgumentsParseTree.getChildCount() == 1);
+      builder.setType(ListProtocol.GetType.GET_ALL);
     } else if (2 == numArguments) {
-      // get one
+      // GET_ONE
+      Preconditions.checkState(listGetArgumentsParseTree.getChildCount() == 2);
+      builder.setType(ListProtocol.GetType.GET_ONE);
+      builder.setIndex(Integer.valueOf(listGetArgumentsParseTree.getChild(1).getText()));
     } else if (3 == numArguments) {
-      // get range
+      // GET_RANGE
+      Preconditions.checkState(listGetArgumentsParseTree.getChildCount() == 3);
+      builder.setType(ListProtocol.GetType.GET_RANGE);
+      builder.setFrom(Integer.valueOf(listGetArgumentsParseTree.getChild(1).getText()));
+      builder.setEnd(Integer.valueOf(listGetArgumentsParseTree.getChild(2).getText()));
     } else {
-      // exception
+      throw new RuntimeException("Failed to parser the command.");
     }
 
+    parsedResult = new DstParsedResult(RequestTypeEnum.LIST_GET, builder.build());
   }
 
   @Override

--- a/rpc/src/main/java/org/dst/rpc/protobuf/common_pb.proto
+++ b/rpc/src/main/java/org/dst/rpc/protobuf/common_pb.proto
@@ -9,8 +9,11 @@ enum Status {
     OK = 0;
     KEY_NOT_FOUND = 1;
     UNKNOWN_ERROR = 2;
+    UNKNOWN_REQUEST_TYPE = 3;
+    LIST_INDEX_OUT_OF_BOUNDS = 4;
+
     // The key of the dict is not found.
-    DICT_KEY_NOT_FOUND = 3;
+    DICT_KEY_NOT_FOUND = 5;
 };
 
 // Drop the k-v pair by the given key.

--- a/rpc/src/main/java/org/dst/rpc/protobuf/list_pb.proto
+++ b/rpc/src/main/java/org/dst/rpc/protobuf/list_pb.proto
@@ -17,8 +17,24 @@ message PutResponse {
     required Status status = 1;
 }
 
+// The type of a `get` request.
+//
+// GET_ALL indicates we should get all of the values of the specific key.
+// GET_ONE indicates we should get a value of the specific index.
+// GET_RANGE indicates that we should get the values of a range index.
+enum GetType {
+    GET_ALL = 0;
+    GET_ONE = 1;
+    GET_RANGE = 2;
+};
+
+// TODO(qwang): comment on this.
 message GetRequest {
-    required string key = 1;
+    required GetType type = 1;
+    required string key = 2;
+    optional int32 index = 3;
+    optional int32 from = 4;
+    optional int32 end = 5;
 }
 
 message GetResponse {

--- a/server/src/main/java/org/dst/server/service/DstListServiceImpl.java
+++ b/server/src/main/java/org/dst/server/service/DstListServiceImpl.java
@@ -3,6 +3,8 @@ package org.dst.server.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.google.common.base.Preconditions;
 import org.dst.core.KVStore;
 import org.dst.common.exception.DstException;
 import org.dst.common.exception.KeyNotFoundException;
@@ -43,13 +45,31 @@ public class DstListServiceImpl extends DstBaseService implements DstListService
     ListProtocol.GetResponse.Builder responseBuilder =
             ListProtocol.GetResponse.newBuilder();
     CommonProtocol.Status status = CommonProtocol.Status.OK;
+
+    final String key = request.getKey();
+    final ListProtocol.GetType type = request.getType();
     try {
-      List<String> values = getStore().lists().get(request.getKey());
-      Optional.ofNullable(values).ifPresent(v -> responseBuilder.addAllValues(values));
+      if (type == ListProtocol.GetType.GET_ALL) {
+        final List<String> values = getStore().lists().get(key);
+        Optional.ofNullable(values).ifPresent(v -> responseBuilder.addAllValues(values));
+      } else if (type == ListProtocol.GetType.GET_ONE) {
+        Preconditions.checkState(request.getIndex() >= 0);
+        responseBuilder.addValues(getStore().lists().get(key, request.getIndex()));
+      } else if (type == ListProtocol.GetType.GET_RANGE) {
+        final List<String> values = getStore().lists().get(key, request.getFrom(), request.getEnd());
+        Optional.ofNullable(values).ifPresent(v -> responseBuilder.addAllValues(values));
+      } else {
+        // TODO(qwang): Handle index out of bound exception.
+      }
+
     } catch (KeyNotFoundException e) {
-      LOGGER.error("Failed to get a list from store: {1}", e);
+      LOGGER.info("Failed to get a list from store: {1}", e);
       status = CommonProtocol.Status.KEY_NOT_FOUND;
+    } catch (IndexOutOfBoundsException e) {
+      LOGGER.info("Failed to get a list from store: {1}", e);
+      status = CommonProtocol.Status.IndexOutOfBound;
     }
+
     responseBuilder.setStatus(status);
     return responseBuilder.build();
   }

--- a/test/src/test/java/org/dst/test/core/operator/KVSListTest.java
+++ b/test/src/test/java/org/dst/test/core/operator/KVSListTest.java
@@ -3,6 +3,7 @@ package org.dst.test.core.operator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import com.google.common.collect.ImmutableList;
 import org.dst.core.KVStoreImpl;
 import org.dst.core.KVStore;
 import org.dst.common.exception.KeyNotFoundException;
@@ -19,12 +20,14 @@ public class KVSListTest {
     return list;
   }
 
-
   @Test
   public void testPutAndGet() {
     KVStore store = new KVStoreImpl();
+    // Note that the list is `v1 v2 v3`.
     store.lists().put("k1", listForKVSTest());
     Assert.assertEquals(listForKVSTest(), store.lists().get("k1"));
+    Assert.assertEquals(store.lists().get("k1", 1), "v2");
+    Assert.assertEquals(store.lists().get("k1", 1, 3), ImmutableList.of("v2", "v3"));
   }
 
   @Test(expectedExceptions = KeyNotFoundException.class)
@@ -56,8 +59,7 @@ public class KVSListTest {
     store.lists().rput("k1", list2);
     Assert.assertEquals(Arrays.asList("v1", "v2", "v3", "v4", "v5"), store.lists().get("k1"));
   }
-
-
+  
   @Test
   public void testLDel() {
     KVStore store = new KVStoreImpl();
@@ -66,7 +68,6 @@ public class KVSListTest {
     Assert.assertEquals(Arrays.asList("v2", "v3"), store.lists().get("k1"));
     Assert.assertEquals("key not exist", store.lists().ldel("-k", 1).toString());
   }
-
 
   @Test
   public void testRDel() {

--- a/test/src/test/java/org/dst/test/core/operator/KVSListTest.java
+++ b/test/src/test/java/org/dst/test/core/operator/KVSListTest.java
@@ -59,7 +59,7 @@ public class KVSListTest {
     store.lists().rput("k1", list2);
     Assert.assertEquals(Arrays.asList("v1", "v2", "v3", "v4", "v5"), store.lists().get("k1"));
   }
-  
+
   @Test
   public void testLDel() {
     KVStore store = new KVStoreImpl();

--- a/test/src/test/java/org/dst/test/parser/ParseListCommandTest.java
+++ b/test/src/test/java/org/dst/test/parser/ParseListCommandTest.java
@@ -75,16 +75,6 @@ public class ParseListCommandTest {
   }
 
   @Test
-  public void testLdel() {
-    final String command = "list.ldel k1 100";
-    DstParsedResult result = dstParser.parse(command);
-    Assert.assertEquals(result.getRequestType(), RequestTypeEnum.LIST_LDEL);
-    ListProtocol.LDelRequest request = (ListProtocol.LDelRequest) result.getRequest();
-    Assert.assertEquals(request.getKey(), "k1");
-    Assert.assertEquals(request.getIndex(), 100);
-  }
-
-  @Test
   public void testRdel() {
     // TODO(qwang): Should be finished.
   }

--- a/test/src/test/java/org/dst/test/parser/ParseListCommandTest.java
+++ b/test/src/test/java/org/dst/test/parser/ParseListCommandTest.java
@@ -25,12 +25,36 @@ public class ParseListCommandTest {
   }
 
   @Test
-  public void testGet() {
+  public void testGetAll() {
     final String command = "list.get k1";
     DstParsedResult result = dstParser.parse(command);
     Assert.assertEquals(result.getRequestType(), RequestTypeEnum.LIST_GET);
     ListProtocol.GetRequest request = (ListProtocol.GetRequest) result.getRequest();
+    Assert.assertEquals(request.getType(), ListProtocol.GetType.GET_ALL);
     Assert.assertEquals(request.getKey(), "k1");
+  }
+
+  @Test
+  public void testGetOne() {
+    final String command = "list.get k1 3";
+    DstParsedResult result = dstParser.parse(command);
+    Assert.assertEquals(result.getRequestType(), RequestTypeEnum.LIST_GET);
+    ListProtocol.GetRequest request = (ListProtocol.GetRequest) result.getRequest();
+    Assert.assertEquals(request.getType(), ListProtocol.GetType.GET_ONE);
+    Assert.assertEquals(request.getKey(), "k1");
+    Assert.assertEquals(request.getIndex(), 3);
+  }
+
+  @Test
+  public void testGetRange() {
+    final String command = "list.get k1 4 9";
+    DstParsedResult result = dstParser.parse(command);
+    Assert.assertEquals(result.getRequestType(), RequestTypeEnum.LIST_GET);
+    ListProtocol.GetRequest request = (ListProtocol.GetRequest) result.getRequest();
+    Assert.assertEquals(request.getType(), ListProtocol.GetType.GET_RANGE);
+    Assert.assertEquals(request.getKey(), "k1");
+    Assert.assertEquals(request.getFrom(), 4);
+    Assert.assertEquals(request.getEnd(), 9);
   }
 
   @Test

--- a/test/src/test/java/org/dst/test/server/service/ListRpcTest.java
+++ b/test/src/test/java/org/dst/test/server/service/ListRpcTest.java
@@ -33,6 +33,7 @@ public class ListRpcTest extends BaseTestSupplier {
 
       //get
       ListProtocol.GetRequest.Builder getRequestBuilder = ListRpcTestUtil.getRequestBuilder();
+      getRequestBuilder.setType(ListProtocol.GetType.GET_ALL);
       getRequestBuilder.setKey("k1");
       ListProtocol.GetResponse getResponseBuilder =
             ListRpcTestUtil.getResponseBuilder(getRequestBuilder, proxy);
@@ -41,6 +42,7 @@ public class ListRpcTest extends BaseTestSupplier {
       //get
       ListProtocol.GetRequest.Builder getRequest2Builder = ListRpcTestUtil.getRequestBuilder();
       getRequest2Builder.setKey("k2");
+      getRequest2Builder.setType(ListProtocol.GetType.GET_ALL);
       ListProtocol.GetResponse getResponse2Builder =
               ListRpcTestUtil.getResponseBuilder(getRequest2Builder, proxy);
       Assert.assertEquals(CommonProtocol.Status.KEY_NOT_FOUND, getResponse2Builder.getStatus());
@@ -103,6 +105,7 @@ public class ListRpcTest extends BaseTestSupplier {
       //get
       ListProtocol.GetRequest.Builder getRequestBuilder = ListRpcTestUtil.getRequestBuilder();
       getRequestBuilder.setKey("k1");
+      getRequestBuilder.setType(ListProtocol.GetType.GET_ALL);
       ListProtocol.GetResponse getResponseBuilder =
             ListRpcTestUtil.getResponseBuilder(getRequestBuilder, proxy);
       Assert.assertEquals(ImmutableList.of("v3", "v4", "v0", "v1", "v2"),
@@ -148,6 +151,7 @@ public class ListRpcTest extends BaseTestSupplier {
       //get
       ListProtocol.GetRequest.Builder getRequestBuilder = ListRpcTestUtil.getRequestBuilder();
       getRequestBuilder.setKey("k1");
+      getRequestBuilder.setType(ListProtocol.GetType.GET_ALL);
       ListProtocol.GetResponse getResponseBuilder =
             ListRpcTestUtil.getResponseBuilder(getRequestBuilder, proxy);
       Assert.assertEquals(ImmutableList.of("v0", "v1", "v2", "v3", "v4"),
@@ -189,6 +193,7 @@ public class ListRpcTest extends BaseTestSupplier {
       //get
       ListProtocol.GetRequest.Builder getRequestBuilder = ListRpcTestUtil.getRequestBuilder();
       getRequestBuilder.setKey("k1");
+      getRequestBuilder.setType(ListProtocol.GetType.GET_ALL);
       ListProtocol.GetResponse getResponseBuilder =
             ListRpcTestUtil.getResponseBuilder(getRequestBuilder, proxy);
       Assert.assertEquals(ImmutableList.of("v1", "v2"), getResponseBuilder.getValuesList());
@@ -226,6 +231,7 @@ public class ListRpcTest extends BaseTestSupplier {
       //get
       ListProtocol.GetRequest.Builder getRequestBuilder = ListRpcTestUtil.getRequestBuilder();
       getRequestBuilder.setKey("k1");
+      getRequestBuilder.setType(ListProtocol.GetType.GET_ALL);
       ListProtocol.GetResponse getResponseBuilder =
             ListRpcTestUtil.getResponseBuilder(getRequestBuilder, proxy);
       Assert.assertEquals(ImmutableList.of("v0", "v1"), getResponseBuilder.getValuesList());


### PR DESCRIPTION
This PR is the part of supporting completed `list.get` semantics:
```bash
list.get key [index / from end]
```
1. Get all values of the key:
```bash
list.get key
```

2. Get the specific value of the given index from the list.
```bash
list.get key index
```

3. Get the values of the given range from the list:
```bash
list.get key from end
```
