### PR TITLE
Support string handler on new `Dst Executor` with worker pool

### DIFF
--- a/common/src/main/java/com/distkv/dst/common/NodeInfo.java
+++ b/common/src/main/java/com/distkv/dst/common/NodeInfo.java
@@ -1,0 +1,14 @@
+package com.distkv.dst.common;
+
+public class NodeInfo {
+  // NodeId nodeId;
+  private boolean isMaster;
+
+  public NodeInfo(boolean isMaster) {
+    this.isMaster = isMaster;
+  }
+
+  public boolean isMaster() {
+    return isMaster;
+  }
+}

--- a/common/src/main/java/com/distkv/dst/common/RequestTypeEnum.java
+++ b/common/src/main/java/com/distkv/dst/common/RequestTypeEnum.java
@@ -1,4 +1,4 @@
-package com.distkv.dst.parser.po;
+package com.distkv.dst.common;
 
 public enum RequestTypeEnum {
   STR_PUT,

--- a/parser/src/main/java/com/distkv/dst/parser/DstNewSqlListener.java
+++ b/parser/src/main/java/com/distkv/dst/parser/DstNewSqlListener.java
@@ -1,6 +1,6 @@
 package com.distkv.dst.parser;
 
-import com.distkv.dst.parser.po.RequestTypeEnum;
+import com.distkv.dst.common.RequestTypeEnum;
 import com.google.common.base.Preconditions;
 import org.antlr.v4.runtime.tree.ParseTree;
 import com.distkv.dst.parser.generated.DstNewSQLBaseListener;

--- a/parser/src/main/java/com/distkv/dst/parser/po/DstParsedResult.java
+++ b/parser/src/main/java/com/distkv/dst/parser/po/DstParsedResult.java
@@ -1,5 +1,7 @@
 package com.distkv.dst.parser.po;
 
+import com.distkv.dst.common.RequestTypeEnum;
+
 public class DstParsedResult {
   public RequestTypeEnum requestType;
   public Object request;

--- a/server/src/main/java/com/distkv/dst/server/runtime/DstRuntime.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/DstRuntime.java
@@ -1,0 +1,5 @@
+package com.distkv.dst.server.runtime;
+
+public class DstRuntime {
+
+}

--- a/server/src/main/java/com/distkv/dst/server/runtime/DstRuntime.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/DstRuntime.java
@@ -1,5 +1,19 @@
 package com.distkv.dst.server.runtime;
 
+import com.distkv.dst.server.runtime.workerpool.WorkerPool;
+
 public class DstRuntime {
+
+  private static final int shardNum = 8;
+
+  private WorkerPool workerPool;
+
+  public DstRuntime() {
+    workerPool = new WorkerPool(shardNum);
+  }
+
+  public WorkerPool getWorkerPool() {
+    return workerPool;
+  }
 
 }

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/InternalRequest.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/InternalRequest.java
@@ -1,0 +1,31 @@
+package com.distkv.dst.server.runtime.workerpool;
+
+import com.distkv.dst.common.RequestTypeEnum;
+
+public class InternalRequest {
+
+  private RequestTypeEnum requestType;
+
+  private Object request;
+
+  private Object completableFuture;
+
+  public InternalRequest(RequestTypeEnum requestType, Object request, Object completableFuture) {
+    this.requestType = requestType;
+    this.request = request;
+    this.completableFuture = completableFuture;
+  }
+
+  public Object getRequest() {
+    return request;
+  }
+
+  public Object getCompletableFuture() {
+    return completableFuture;
+  }
+
+  public RequestTypeEnum getRequestType() {
+    return requestType;
+  }
+
+}

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/NodeInstance.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/NodeInstance.java
@@ -1,0 +1,4 @@
+package com.distkv.dst.server.runtime.workerpool;
+
+public class NodeInstance {
+}

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
@@ -23,11 +23,6 @@ public class Worker extends Thread {
     queue = new LinkedBlockingQueue<>();
   }
 
-  /**
-   * The blocking queue to used for queue the requests.
-   */
-  // TODO(qwang): Remove the class DstConcurrentQueue.
-  //private DstConcurrentQueue<Object> queue;
   private BlockingQueue<InternalRequest> queue;
 
   // Note that this method is threading-safe.

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
@@ -40,6 +40,7 @@ public class Worker extends Thread {
    */
   private KVStore storeEngine = new KVStoreImpl();
 
+  @SuppressWarnings({"unchecked"})
   @Override
   public void run() {
     while (true) {
@@ -64,14 +65,16 @@ public class Worker extends Thread {
             StringProtocol.GetRequest strGetRequest = (StringProtocol.GetRequest)
                 internalRequest.getRequest();
             String value = storeEngine.strs().get(strGetRequest.getKey());
+            StringProtocol.GetResponse.Builder builder = StringProtocol.GetResponse.newBuilder();
+            if (value == null) {
+              builder.setStatus(CommonProtocol.Status.KEY_NOT_FOUND);
+            } else {
+              builder.setStatus(CommonProtocol.Status.OK).setValue(value);
+            }
             CompletableFuture<StringProtocol.GetResponse> future =
                 (CompletableFuture<StringProtocol.GetResponse>)
                     internalRequest.getCompletableFuture();
-            StringProtocol.GetResponse response = StringProtocol.GetResponse.newBuilder()
-                .setStatus(CommonProtocol.Status.OK)
-                .setValue(value)
-                .build();
-            future.complete(response);
+            future.complete(builder.build());
             break;
           }
           default:

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
@@ -1,7 +1,6 @@
 package com.distkv.dst.server.runtime.workerpool;
 
 import com.distkv.dst.common.NodeInfo;
-import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.core.KVStore;
 import com.distkv.dst.core.KVStoreImpl;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
@@ -10,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class Worker extends Thread {
 
@@ -18,6 +18,10 @@ public class Worker extends Thread {
   private NodeInstance nodeInstance;
 
   private static Logger LOGGER = LoggerFactory.getLogger(Worker.class);
+
+  public Worker() {
+    queue = new LinkedBlockingQueue<>();
+  }
 
   /**
    * The blocking queue to used for queue the requests.
@@ -44,26 +48,39 @@ public class Worker extends Thread {
         switch (internalRequest.getRequestType()) {
           case STR_PUT:
           {
-            StringProtocol.PutRequest strPutRequest = (StringProtocol.PutRequest) internalRequest.getRequest();
+            StringProtocol.PutRequest strPutRequest =
+                (StringProtocol.PutRequest) internalRequest.getRequest();
             // try put.
             storeEngine.strs().put(strPutRequest.getKey(), strPutRequest.getValue());
-            CompletableFuture<StringProtocol.PutResponse> future = (CompletableFuture<StringProtocol.PutResponse>) internalRequest.getCompletableFuture();
-            future.complete(StringProtocol.PutResponse.newBuilder().setStatus(CommonProtocol.Status.OK).build());
+            CompletableFuture<StringProtocol.PutResponse> future =
+                (CompletableFuture<StringProtocol.PutResponse>)
+                    internalRequest.getCompletableFuture();
+            future.complete(StringProtocol.PutResponse.newBuilder()
+                .setStatus(CommonProtocol.Status.OK).build());
+            break;
           }
           case STR_GET:
           {
-            StringProtocol.GetRequest strGetRequest = (StringProtocol.GetRequest) internalRequest.getRequest();
+            StringProtocol.GetRequest strGetRequest = (StringProtocol.GetRequest)
+                internalRequest.getRequest();
             String value = storeEngine.strs().get(strGetRequest.getKey());
-            CompletableFuture<StringProtocol.GetResponse> future = (CompletableFuture<StringProtocol.GetResponse>) internalRequest.getCompletableFuture();
+            CompletableFuture<StringProtocol.GetResponse> future =
+                (CompletableFuture<StringProtocol.GetResponse>)
+                    internalRequest.getCompletableFuture();
             StringProtocol.GetResponse response = StringProtocol.GetResponse.newBuilder()
                 .setStatus(CommonProtocol.Status.OK)
                 .setValue(value)
                 .build();
             future.complete(response);
+            break;
+          }
+          default:
+          {
+
           }
         }
       } catch (Exception e) {
-        LOGGER.error("Failed to execute event loop.");
+        LOGGER.error("Failed to execute event loop:" + e);
       }
     }
   }

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/Worker.java
@@ -1,0 +1,85 @@
+package com.distkv.dst.server.runtime.workerpool;
+
+import com.distkv.dst.common.NodeInfo;
+import com.distkv.dst.common.RequestTypeEnum;
+import com.distkv.dst.core.KVStore;
+import com.distkv.dst.core.KVStoreImpl;
+import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
+import com.distkv.dst.rpc.protobuf.generated.StringProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+
+public class Worker extends Thread {
+
+  private NodeInfo nodeInfo;
+
+  private NodeInstance nodeInstance;
+
+  private static Logger LOGGER = LoggerFactory.getLogger(Worker.class);
+
+  /**
+   * The blocking queue to used for queue the requests.
+   */
+  // TODO(qwang): Remove the class DstConcurrentQueue.
+  //private DstConcurrentQueue<Object> queue;
+  private BlockingQueue<InternalRequest> queue;
+
+  public void post(InternalRequest internalRequest) throws InterruptedException {
+    queue.put(internalRequest);
+  }
+
+  /**
+   * Store engine.
+   */
+  private KVStore storeEngine = new KVStoreImpl();
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        InternalRequest internalRequest = queue.take();
+        switch (internalRequest.requestType) {
+          case STR_PUT:
+          {
+            StringProtocol.PutRequest strPutRequest = (StringProtocol.PutRequest) internalRequest.request;
+            // try put.
+            storeEngine.strs().put(strPutRequest.getKey(), strPutRequest.getValue());
+            CompletableFuture<StringProtocol.PutResponse> future = (CompletableFuture<StringProtocol.PutResponse>) internalRequest.completableFuture;
+            future.complete(StringProtocol.PutResponse.newBuilder().setStatus(CommonProtocol.Status.OK).build());
+          }
+          case STR_GET:
+          {
+            StringProtocol.GetRequest strGetRequest = (StringProtocol.GetRequest) internalRequest.request;
+            String value = storeEngine.strs().get(strGetRequest.getKey());
+            CompletableFuture<StringProtocol.GetResponse> future = (CompletableFuture<StringProtocol.GetResponse>) internalRequest.completableFuture;
+            StringProtocol.GetResponse response = StringProtocol.GetResponse.newBuilder()
+                .setStatus(CommonProtocol.Status.OK)
+                .setValue(value)
+                .build();
+            future.complete(response);
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error("Failed to execute event loop.");
+      }
+    }
+  }
+
+  private class InternalRequest {
+
+    private RequestTypeEnum requestType;
+
+    private Object request;
+
+    private Object completableFuture;
+
+    public InternalRequest(RequestTypeEnum requestType, Object request, Object completableFuture) {
+      this.requestType = requestType;
+      this.request = request;
+      this.completableFuture = completableFuture;
+    }
+  }
+
+}

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
@@ -31,6 +31,7 @@ public class WorkerPool {
     try {
       worker.post(new InternalRequest(requestType, request, completableFuture));
     } catch (InterruptedException e) {
+      // TODO(qwang): Should be an assert here.
       LOGGER.error("Failed to post request to worker pool, key is {}", key);
     }
   }

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
@@ -1,12 +1,7 @@
 package com.distkv.dst.server.runtime.workerpool;
 
 import com.distkv.dst.common.RequestTypeEnum;
-import com.distkv.dst.common.id.ShardId;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 public class WorkerPool {
 
@@ -14,7 +9,7 @@ public class WorkerPool {
 
   //private HashMap<ShardId, Worker> workers;
 
-  final private ImmutableList<Worker> workers;
+  private final ImmutableList<Worker> workers;
 
   public WorkerPool(int shardNum) {
     this.shardNum = shardNum;
@@ -27,7 +22,8 @@ public class WorkerPool {
     workers = builder.build();
   }
 
-  public void postRequest(String key, RequestTypeEnum requestType, Object request, Object completableFuture) {
+  public void postRequest(
+      String key, RequestTypeEnum requestType, Object request, Object completableFuture) {
     final int workerIndex = key.hashCode() % shardNum;
     Worker worker = workers.get(workerIndex);
     try {

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
@@ -1,0 +1,5 @@
+package com.distkv.dst.server.runtime.workerpool;
+
+public class WorkerPool {
+
+}

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
@@ -1,5 +1,40 @@
 package com.distkv.dst.server.runtime.workerpool;
 
+import com.distkv.dst.common.RequestTypeEnum;
+import com.distkv.dst.common.id.ShardId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 public class WorkerPool {
+
+  private final int shardNum;
+
+  //private HashMap<ShardId, Worker> workers;
+
+  final private ImmutableList<Worker> workers;
+
+  public WorkerPool(int shardNum) {
+    this.shardNum = shardNum;
+    ImmutableList.Builder<Worker> builder = new ImmutableList.Builder<>();
+    for (int i = 0; i < shardNum; ++i) {
+      Worker worker = new Worker();
+      builder.add(worker);
+      worker.start();
+    }
+    workers = builder.build();
+  }
+
+  public void postRequest(String key, RequestTypeEnum requestType, Object request, Object completableFuture) {
+    final int workerIndex = key.hashCode() % shardNum;
+    Worker worker = workers.get(workerIndex);
+    try {
+      worker.post(new InternalRequest(requestType, request, completableFuture));
+    } catch (InterruptedException e) {
+      // TODO(qwang): xxxxx
+    }
+  }
 
 }

--- a/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
+++ b/server/src/main/java/com/distkv/dst/server/runtime/workerpool/WorkerPool.java
@@ -2,12 +2,14 @@ package com.distkv.dst.server.runtime.workerpool;
 
 import com.distkv.dst.common.RequestTypeEnum;
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WorkerPool {
 
-  private final int shardNum;
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerPool.class);
 
-  //private HashMap<ShardId, Worker> workers;
+  private final int shardNum;
 
   private final ImmutableList<Worker> workers;
 
@@ -29,7 +31,7 @@ public class WorkerPool {
     try {
       worker.post(new InternalRequest(requestType, request, completableFuture));
     } catch (InterruptedException e) {
-      // TODO(qwang): xxxxx
+      LOGGER.error("Failed to post request to worker pool, key is {}", key);
     }
   }
 

--- a/server/src/main/java/com/distkv/dst/server/service/DstServer.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstServer.java
@@ -74,7 +74,6 @@ public class DstServer {
     // TODO(qwang): Rename exporter to DrcpServer.
     Exporter exporter = new Exporter(serverConfig);
     // TODO(qwang): Refine this protocol name.
-    exporter.setProtocol("dst");
 
     exporter.registerService(
         DstStringService.class, new DstStringServiceImpl(server.runtime));

--- a/server/src/main/java/com/distkv/dst/server/service/DstServer.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstServer.java
@@ -82,7 +82,7 @@ public class DstServer {
     exporter.registerService(
         DstDictService.class, new DstDictServiceImpl(server.getKvStore()));
     exporter.registerService(
-        DstSortedListService.class, new DstSortedListServiceImpl(rpcServer.getKvStore()));
+        DstSortedListService.class, new DstSortedListServiceImpl(server.getKvStore()));
     // TODO(qwang): Rename this to drpcServer.run();
     exporter.export();
 

--- a/server/src/main/java/com/distkv/dst/server/service/DstServer.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstServer.java
@@ -8,6 +8,7 @@ import com.distkv.dst.rpc.service.DstListService;
 import com.distkv.dst.rpc.service.DstStringService;
 import com.distkv.dst.rpc.service.DstSetService;
 import com.distkv.dst.rpc.service.DstSortedListService;
+import com.distkv.dst.server.runtime.DstRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,8 +21,11 @@ public class DstServer {
   // TODO(qwang): This should be a Dst Runtime.
   private KVStore kvStore;
 
+  private DstRuntime runtime;
+
   private DstServer() {
     kvStore = new KVStoreImpl();
+    runtime = new DstRuntime();
   }
 
   private KVStore getKvStore() {
@@ -48,7 +52,7 @@ public class DstServer {
 
   public static void main(String[] args) {
 
-    DstServer rpcServer = new DstServer();
+    DstServer server = new DstServer();
 
     int listeningPort = LISTENING_PORT;
 
@@ -66,15 +70,15 @@ public class DstServer {
     Exporter exporter = new Exporter();
     // TODO(qwang): Refine this protocol name.
     exporter.setProtocol("dst");
-    exporter.registerService(DstStringService.class, new DstStringServiceImpl());
+    exporter.registerService(DstStringService.class, new DstStringServiceImpl(server.runtime));
     exporter.registerService(
-        DstListService.class, new DstListServiceImpl(rpcServer.getKvStore()));
+        DstListService.class, new DstListServiceImpl(server.getKvStore()));
     exporter.registerService(
-        DstSetService.class, new DstSetServiceImpl(rpcServer.getKvStore()));
+        DstSetService.class, new DstSetServiceImpl(server.getKvStore()));
     exporter.registerService(
-        DstDictService.class, new DstDictServiceImpl(rpcServer.getKvStore()));
+        DstDictService.class, new DstDictServiceImpl(server.getKvStore()));
     exporter.registerService(
-        DstSortedListService.class, new DstSortedListServiceImpl(rpcServer.getKvStore()));
+        DstSortedListService.class, new DstSortedListServiceImpl(server.getKvStore()));
     exporter.isLocal(false);
     exporter.setPort(listeningPort);
 

--- a/server/src/main/java/com/distkv/dst/server/service/DstServer.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstServer.java
@@ -66,8 +66,7 @@ public class DstServer {
     Exporter exporter = new Exporter();
     // TODO(qwang): Refine this protocol name.
     exporter.setProtocol("dst");
-    exporter.registerService(
-        DstStringService.class, new DstStringServiceImpl(rpcServer.getKvStore()));
+    exporter.registerService(DstStringService.class, new DstStringServiceImpl());
     exporter.registerService(
         DstListService.class, new DstListServiceImpl(rpcServer.getKvStore()));
     exporter.registerService(

--- a/server/src/main/java/com/distkv/dst/server/service/DstServer.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstServer.java
@@ -73,8 +73,6 @@ public class DstServer {
 
     // TODO(qwang): Rename exporter to DrcpServer.
     Exporter exporter = new Exporter(serverConfig);
-    // TODO(qwang): Refine this protocol name.
-
     exporter.registerService(
         DstStringService.class, new DstStringServiceImpl(server.runtime));
     exporter.registerService(

--- a/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
@@ -1,59 +1,46 @@
 package com.distkv.dst.server.service;
 
+import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.common.utils.FutureUtils;
 import com.distkv.dst.core.KVStore;
 import com.distkv.dst.server.base.DstBaseService;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
 import com.distkv.dst.rpc.protobuf.generated.StringProtocol;
 import com.distkv.dst.rpc.service.DstStringService;
+import com.distkv.dst.server.runtime.DstRuntime;
+import com.distkv.dst.server.runtime.workerpool.WorkerPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.concurrent.CompletableFuture;
 
-public class DstStringServiceImpl extends DstBaseService implements DstStringService {
+public class DstStringServiceImpl implements DstStringService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DstStringServiceImpl.class);
 
-  public DstStringServiceImpl(KVStore store) {
-    super(store);
-  }
+  private WorkerPool workerPool = new WorkerPool(5);
 
+  public DstStringServiceImpl() {
+  }
 
   @Override
   public CompletableFuture<StringProtocol.PutResponse> put(StringProtocol.PutRequest request) {
-    StringProtocol.PutResponse.Builder responseBuilder =
-            StringProtocol.PutResponse.newBuilder();
-    getStore().strs().put(request.getKey(), request.getValue());
-    responseBuilder.setStatus(CommonProtocol.Status.OK);
-    return FutureUtils.newCompletableFuture(responseBuilder.build());
+    CompletableFuture<StringProtocol.PutResponse> future = new CompletableFuture<StringProtocol.PutResponse>();
+    workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_PUT, request, future);
+    return future;
   }
 
   @Override
   public CompletableFuture<StringProtocol.GetResponse> get(StringProtocol.GetRequest request) {
-    StringProtocol.GetResponse.Builder responseBuilder =
-            StringProtocol.GetResponse.newBuilder();
-
-    String value = getStore().strs().get(request.getKey());
-    if (value != null) {
-      responseBuilder.setValue(getStore().strs().get(request.getKey()));
-      responseBuilder.setStatus(CommonProtocol.Status.OK);
-    } else {
-      responseBuilder.setStatus(CommonProtocol.Status.KEY_NOT_FOUND);
-    }
-    return FutureUtils.newCompletableFuture(responseBuilder.build());
+    CompletableFuture<StringProtocol.GetResponse> future = new CompletableFuture<StringProtocol.GetResponse>();
+    workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_GET, request, future);
+    return future;
   }
 
   @Override
   public CompletableFuture<CommonProtocol.DropResponse> drop(CommonProtocol.DropRequest request) {
-    CommonProtocol.DropResponse.Builder responseBuilder =
-            CommonProtocol.DropResponse.newBuilder();
-
-    responseBuilder.setStatus(CommonProtocol.Status.OK);
-    if (!getStore().strs().drop(request.getKey())) {
-      responseBuilder.setStatus(CommonProtocol.Status.KEY_NOT_FOUND);
-    }
-    return FutureUtils.newCompletableFuture(responseBuilder.build());
+    throw new NotImplementedException();
   }
 
 }

--- a/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
@@ -4,7 +4,7 @@ import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
 import com.distkv.dst.rpc.protobuf.generated.StringProtocol;
 import com.distkv.dst.rpc.service.DstStringService;
-import com.distkv.dst.server.runtime.workerpool.WorkerPool;
+import com.distkv.dst.server.runtime.DstRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
@@ -15,22 +15,23 @@ public class DstStringServiceImpl implements DstStringService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DstStringServiceImpl.class);
 
-  private WorkerPool workerPool = new WorkerPool(1);
+  private DstRuntime runtime;
 
-  public DstStringServiceImpl() {
+  public DstStringServiceImpl(DstRuntime runtime) {
+    this.runtime = runtime;
   }
 
   @Override
   public CompletableFuture<StringProtocol.PutResponse> put(StringProtocol.PutRequest request) {
     CompletableFuture<StringProtocol.PutResponse> future = new CompletableFuture<>();
-    workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_PUT, request, future);
+    runtime.getWorkerPool().postRequest(request.getKey(), RequestTypeEnum.STR_PUT, request, future);
     return future;
   }
 
   @Override
   public CompletableFuture<StringProtocol.GetResponse> get(StringProtocol.GetRequest request) {
     CompletableFuture<StringProtocol.GetResponse> future = new CompletableFuture<>();
-    workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_GET, request, future);
+    runtime.getWorkerPool().postRequest(request.getKey(), RequestTypeEnum.STR_GET, request, future);
     return future;
   }
 

--- a/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
+++ b/server/src/main/java/com/distkv/dst/server/service/DstStringServiceImpl.java
@@ -1,13 +1,9 @@
 package com.distkv.dst.server.service;
 
 import com.distkv.dst.common.RequestTypeEnum;
-import com.distkv.dst.common.utils.FutureUtils;
-import com.distkv.dst.core.KVStore;
-import com.distkv.dst.server.base.DstBaseService;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
 import com.distkv.dst.rpc.protobuf.generated.StringProtocol;
 import com.distkv.dst.rpc.service.DstStringService;
-import com.distkv.dst.server.runtime.DstRuntime;
 import com.distkv.dst.server.runtime.workerpool.WorkerPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,21 +15,21 @@ public class DstStringServiceImpl implements DstStringService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DstStringServiceImpl.class);
 
-  private WorkerPool workerPool = new WorkerPool(5);
+  private WorkerPool workerPool = new WorkerPool(1);
 
   public DstStringServiceImpl() {
   }
 
   @Override
   public CompletableFuture<StringProtocol.PutResponse> put(StringProtocol.PutRequest request) {
-    CompletableFuture<StringProtocol.PutResponse> future = new CompletableFuture<StringProtocol.PutResponse>();
+    CompletableFuture<StringProtocol.PutResponse> future = new CompletableFuture<>();
     workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_PUT, request, future);
     return future;
   }
 
   @Override
   public CompletableFuture<StringProtocol.GetResponse> get(StringProtocol.GetRequest request) {
-    CompletableFuture<StringProtocol.GetResponse> future = new CompletableFuture<StringProtocol.GetResponse>();
+    CompletableFuture<StringProtocol.GetResponse> future = new CompletableFuture<>();
     workerPool.postRequest(request.getKey(), RequestTypeEnum.STR_GET, request, future);
     return future;
   }

--- a/test/src/test/java/com/distkv/dst/test/parser/ParseDictCommandTest.java
+++ b/test/src/test/java/com/distkv/dst/test/parser/ParseDictCommandTest.java
@@ -2,7 +2,7 @@ package com.distkv.dst.test.parser;
 
 import com.distkv.dst.parser.DstParser;
 import com.distkv.dst.parser.po.DstParsedResult;
-import com.distkv.dst.parser.po.RequestTypeEnum;
+import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.DictProtocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/test/src/test/java/com/distkv/dst/test/parser/ParseListCommandTest.java
+++ b/test/src/test/java/com/distkv/dst/test/parser/ParseListCommandTest.java
@@ -3,7 +3,6 @@ package com.distkv.dst.test.parser;
 import com.distkv.dst.common.exception.DstException;
 import com.distkv.dst.parser.DstParser;
 import com.distkv.dst.parser.po.DstParsedResult;
-import com.distkv.dst.parser.po.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
 import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.ListProtocol;

--- a/test/src/test/java/com/distkv/dst/test/parser/ParseListCommandTest.java
+++ b/test/src/test/java/com/distkv/dst/test/parser/ParseListCommandTest.java
@@ -5,6 +5,7 @@ import com.distkv.dst.parser.DstParser;
 import com.distkv.dst.parser.po.DstParsedResult;
 import com.distkv.dst.parser.po.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
+import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.ListProtocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/test/src/test/java/com/distkv/dst/test/parser/ParseStringCommandTest.java
+++ b/test/src/test/java/com/distkv/dst/test/parser/ParseStringCommandTest.java
@@ -5,6 +5,7 @@ import com.distkv.dst.parser.DstParser;
 import com.distkv.dst.parser.po.DstParsedResult;
 import com.distkv.dst.parser.po.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
+import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.StringProtocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/test/src/test/java/com/distkv/dst/test/parser/ParseStringCommandTest.java
+++ b/test/src/test/java/com/distkv/dst/test/parser/ParseStringCommandTest.java
@@ -3,7 +3,6 @@ package com.distkv.dst.test.parser;
 import com.distkv.dst.common.exception.DstException;
 import com.distkv.dst.parser.DstParser;
 import com.distkv.dst.parser.po.DstParsedResult;
-import com.distkv.dst.parser.po.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.CommonProtocol;
 import com.distkv.dst.common.RequestTypeEnum;
 import com.distkv.dst.rpc.protobuf.generated.StringProtocol;

--- a/test/src/test/java/com/distkv/dst/test/supplier/BaseTestSupplier.java
+++ b/test/src/test/java/com/distkv/dst/test/supplier/BaseTestSupplier.java
@@ -19,6 +19,8 @@ public class BaseTestSupplier {
   public void setupBase(Method method) {
     LOGGER.info(String.format("\n==================== Running the test method: %s.%s",
             method.getDeclaringClass(), method.getName()));
+    System.out.println(String.format("\n==================== Running the test method: %s.%s",
+        method.getDeclaringClass(), method.getName()));
     rpcServerPort = (Math.abs(new Random().nextInt() % 10000)) + 10000;
     TestUtil.startRpcServer(rpcServerPort);
   }


### PR DESCRIPTION

This PR implemented a new Dst Executor framework on the top of the current codebase.
And it add a `string handler` for it as an example.

The related issue is https://github.com/dst-project/dst/issues/215