### PR TITLE
Remove unused dependency raft-java

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,23 +17,6 @@
             <artifactId>dst-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.github.wenweihu86.raft</groupId>
-            <artifactId>raft-java-core</artifactId>
-            <version>1.8.0</version>
-            <!--exclude log4j in raft-rpc-core-->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
We use sofajraft to instead of `raft-java`.